### PR TITLE
Fixes to get regression tests to pass

### DIFF
--- a/crmsh/history.py
+++ b/crmsh/history.py
@@ -922,7 +922,7 @@ class Report(object):
         self.manage_excludes("save", p)
         fname = os.path.join(sdir, self.state_file)
         try:
-            f = open(fname, "wb")
+            f = open(fname, "wt")
         except IOError as msg:
             common_err("Failed to save state: %s" % (msg))
             return False

--- a/crmsh/logparser.py
+++ b/crmsh/logparser.py
@@ -609,7 +609,7 @@ class LogParser(object):
         """
         fn = self._metafile()
         try:
-            with open(fn, 'wb') as f:
+            with open(fn, 'wt') as f:
                 json.dump(self.to_dict(), f, indent=2)
                 crmlog.common_debug("Transition metadata saved to %s" % (fn))
         except IOError as e:

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -74,13 +74,13 @@ class Context(object):
             if cmd:
                 rv = self.execute_command() is not False
         except ValueError as msg:
-            if config.core.debug:
+            if config.core.debug or options.regression_tests:
                 import traceback
                 traceback.print_exc()
             common_err("%s: %s" % (self.get_qualified_name(), msg))
             rv = False
         except IOError as msg:
-            if config.core.debug:
+            if config.core.debug or options.regression_tests:
                 import traceback
                 traceback.print_exc()
             common_err("%s: %s" % (self.get_qualified_name(), msg))

--- a/crmsh/ui_history.py
+++ b/crmsh/ui_history.py
@@ -188,11 +188,11 @@ class History(command.UI):
     def ptest(self, nograph, scores, utilization, actions, verbosity):
         'Send a decompressed self.pe_file to ptest'
         try:
-            s = bz2.decompress(open(self.pe_file).read())
+            bits = bz2.decompress(open(self.pe_file, "rb").read())
         except IOError as msg:
             common_err("open: %s" % msg)
             return False
-        return utils.run_ptest(s, nograph, scores, utilization, actions, verbosity)
+        return utils.run_ptest(bits, nograph, scores, utilization, actions, verbosity)
 
     @command.skill_level('administrator')
     def do_events(self, context):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -36,6 +36,9 @@ def to_ascii(s):
     try:
         return str(s, 'utf-8')
     except UnicodeDecodeError:
+        if config.core.debug or options.regression_tests:
+            import traceback
+            traceback.print_exc()
         return s
 
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -382,6 +382,9 @@ def filter_string(cmd, s, stderr_on=True, shell=True):
                          stdout=subprocess.PIPE,
                          stderr=stderr)
     try:
+        # bytes expected here
+        if isinstance(s, str):
+            s = s.encode('utf-8')
         ret = p.communicate(s)
         if stderr_on == 'stdout':
             outp = b"\n".join(ret)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1466,14 +1466,15 @@ def get_cib_attributes(cib_f, tag, attr_l, dflt_l):
     val_patt_l = [re.compile('%s="([^"]+)"' % x) for x in attr_l]
     val_l = []
     try:
-        f = open(cib_f).read()
+        f = open(cib_f, "rb").read()
     except IOError as msg:
         common_err(msg)
         return dflt_l
     if os.path.splitext(cib_f)[-1] == '.bz2':
-        cib_s = bz2.decompress(f)
+        cib_bits = bz2.decompress(f)
     else:
-        cib_s = f
+        cib_bits = f
+    cib_s = to_ascii(cib_bits)
     for s in cib_s.split('\n'):
         if s.startswith(open_t):
             i = 0

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -400,16 +400,16 @@ def shadowfile(name):
 def pe2shadow(pe_file, name):
     '''Copy a PE file (or any CIB file) to a shadow.'''
     try:
-        s = open(pe_file).read()
+        bits = open(pe_file, 'rb').read()
     except IOError as msg:
         common_err("open: %s" % msg)
         return False
     # decompresed if it ends with .bz2
     if pe_file.endswith(".bz2"):
-        s = bz2.decompress(s)
+        bits = bz2.decompress(bits)
     # copy input to the shadow
     try:
-        open(shadowfile(name), "w").write(s)
+        open(shadowfile(name), "wb").write(bits)
     except IOError as msg:
         common_err("open: %s" % msg)
         return False


### PR DESCRIPTION
Hi Xin and Larry,

With these changes, it looks like the regression tests are passing now: The only changes are
 - Changes in Pacemaker command output
 - Output reordering due to Python 3 dict keys/values being iterators rather than lists by default
 - Increased logging created by some of these commits

There is one apparent bug: In the history test case, the end time of the history report is not found correctly. I will look at that, but feel free to fix it if you find the problem :)
