### PR TITLE
crmsh for corosync3

### DIFF
--- a/crmsh/conf_parser.py
+++ b/crmsh/conf_parser.py
@@ -1,0 +1,302 @@
+"""
+Module to parse corosync.conf
+
+Maintainer: XLiang@suse.com
+"""
+
+import os
+import re
+from . import corosync
+from . import utils
+
+
+COROSYNC_CONF_TEMPLATE = """
+totem {
+    version: 2
+    crypto_cipher: aes256
+    crypto_hash: sha256
+}
+
+quorum {
+    provider: corosync_votequorum
+}
+
+logging {
+    to_logfile: yes
+    logfile: /var/log/cluster/corosync.log
+    to_syslog: yes
+    timestamp: on
+}
+"""
+
+
+class Dotable(dict):
+    """
+    To make nested python dictionaries (json-like objects)
+    accessable using dot notation
+    http://andyhayden.com/2013/dotable-dictionaries
+    """
+    __delattr__ = dict.__delitem__
+
+    def __init__(self, d):
+        self._refresh(d)
+
+    def _refresh(self, d=None):
+        target = d or self
+        self.update(**dict((k, self.parse(v)) for k, v in target.items()))
+
+    def __setattr__(self, k, value):
+        self.__setitem__(k, value)
+        self._refresh()
+
+    def __getattr__(self, k):
+        self._refresh()
+        return self.get(k, None)
+
+    @classmethod
+    def parse(cls, v):
+        if isinstance(v, dict):
+            return cls(v)
+        elif isinstance(v, list):
+            return [cls.parse(i) for i in v]
+        else:
+            return v
+
+
+class ConfParser(object):
+    """
+    Class to parse config file which format like corosync.conf
+    """
+    VIRTUAL_LIST_NAME = "__list"
+    COROSYNC_KNOWN_SEC_NAMES_WITH_LIST = ("totem.interface", "nodelist.node")
+
+    def __init__(self, config_file=None, config_data=None, sec_names_with_list=()):
+        """
+        Initialize function
+        """
+        self._config_file = None
+        self._config_data = None
+        if config_data:
+            self._config_data = config_data
+        else:
+            self._config_file = config_file or corosync.conf()
+        self._sec_names_with_list = sec_names_with_list or self.COROSYNC_KNOWN_SEC_NAMES_WITH_LIST
+        self._config_inst = None
+
+    def _verify_config_file(self):
+        """
+        Verify config file
+        """
+        if not os.path.exists(self._config_file):
+            raise ValueError("File \"{}\" not exist".format(self._config_file))
+        if not os.path.isfile(self._config_file):
+            raise ValueError("\"{}\" is not a file".format(self._config_file))
+        with open(self._config_file) as f:
+            data = f.read()
+            if len(re.findall("[{}]", data)) % 2 != 0:
+                raise ValueError("{}: Missing closing brace".format(self._config_file))
+
+    def _convert2dict_raw(self, file_content_lines, initial_path=""):
+        """
+        Convert the corosync configuration file to a dictionary
+        """
+        corodict = {}
+        sub_dict = {}
+        index = 0
+
+        for i, line in enumerate(file_content_lines):
+            stripped_line = line.strip()
+            if not stripped_line or stripped_line[0] == '#':
+                continue
+
+            if index > i:
+                continue
+
+            if '{' in stripped_line:
+                sec_name = re.sub("\s*{", "", stripped_line)
+                initial_path += ".{}".format(sec_name) if initial_path else sec_name
+                sub_dict, new_index = self._convert2dict_raw(file_content_lines[i+1:], initial_path)
+                if initial_path in self._sec_names_with_list:
+                    if self.VIRTUAL_LIST_NAME not in corodict:
+                        corodict[self.VIRTUAL_LIST_NAME] = []
+                    corodict[self.VIRTUAL_LIST_NAME].append({sec_name: sub_dict})
+                else:
+                    corodict[sec_name] = sub_dict
+                index = i + new_index
+                initial_path = re.sub("\.{}".format(sec_name), "", initial_path) if "." in initial_path else ""
+            elif ':' in stripped_line:
+                # To parse the line with multi ":", like IPv6 address
+                data = stripped_line.split(':')
+                key, values = data[0], data[1:]
+                corodict[key] = ':'.join(values).strip()
+            elif '}' in stripped_line:
+                return corodict, i+2
+
+        return corodict, index
+
+    def convert2dict(self):
+        """
+        Wrapped _convert2dict_raw function
+        """
+        if self._config_data:
+            _dict, _ = self._convert2dict_raw(self._config_data.splitlines())
+        else:
+            self._verify_config_file()
+            with open(self._config_file) as f:
+                _dict, _ = self._convert2dict_raw(f.read().splitlines())
+        self._config_inst = Dotable.parse(_dict)
+
+    def _unpack_list_in_dict(self, value_list, indentation):
+        """
+        Convert dict list to string
+        """
+        output = ''
+        for item_dict in value_list:
+            output += self._convert2string_raw(item_dict, indentation)
+        return output
+
+    def _unpack_dict(self, key, value, indentation):
+        """
+        Convert dict to string
+        """
+        output = ''
+        if isinstance(value, dict):
+            output += '{}{} {{\n'.format(indentation, key)
+            indentation += '\t'
+            output += self._convert2string_raw(value, indentation)
+            indentation = indentation[:-1]
+            output += '{}}}\n\n'.format(indentation)
+        elif isinstance(value, list):
+            output += self._unpack_list_in_dict(value, indentation)
+        else:
+            output += '{}{}: {}\n'.format(indentation, key, value)
+        return output
+
+    def _convert2string_raw(self, corodict, indentation=''):
+        """
+        Convert a corosync like data dictionary to string
+        """
+        output = ''
+        for key, value in corodict.items():
+            output += self._unpack_dict(key, value, indentation)
+        return output
+
+    def convert2string(self):
+        """
+        Wrapped _convert2string_raw function
+        """
+        return self._convert2string_raw(self._config_inst)
+
+    def _len_of_list(self, path):
+        """
+        """
+        sec_name, *_ = path.split('.')
+        while True:
+            try:
+                return len(eval("self._config_inst.{}.{}".format(sec_name, self.VIRTUAL_LIST_NAME)))
+            except AttributeError:
+                exec("self._config_inst.{} = {{\"{}\": []}}".format(sec_name, self.VIRTUAL_LIST_NAME))
+
+    def _extend_list(self, path):
+        """
+        """
+        name, sub_name, *_ = path.split('.')
+        sub_name_dict = {"{}".format(sub_name): {}}
+        exec("self._config_inst.{}.{}.append({})".format(name, self.VIRTUAL_LIST_NAME, sub_name_dict))
+
+    def _is_list_path(self, path):
+        """
+        """
+        for x in self._sec_names_with_list:
+            if path.startswith(x):
+                return True
+        return False
+
+    def _real_path(self, path, index=0, on_set=False):
+        """
+        """
+        if self._is_list_path(path):
+            _len = self._len_of_list(path)
+            if on_set and _len <= index:
+                self._extend_list(path)
+                index = _len
+            return re.sub("^(\w+)\.", "\\1.{}[{}].".format(self.VIRTUAL_LIST_NAME, index), path)
+        return path
+
+    def get(self, path, index=0):
+        """
+        Gets the value for the path
+
+        path: config path
+        index: known index in section
+        """
+        path = self._real_path(path, index)
+        try:
+            return eval("self._config_inst.{}".format(path))
+        except (AttributeError, IndexError):
+            return None
+
+    def get_all(self, path):
+        """
+        Returns all values matching path
+        """
+        if not self._is_list_path(path):
+            return [self.get(path)]
+        return [self.get(path, index=i) for i in range(self._len_of_list(path))]
+
+    def remove(self, path, index=0):
+        """
+        """
+        value = self.get(path, index)
+        if not value:
+            raise ValueError("Cannot find value on path \"{}:{}\"".format(path, index))
+        real_path = self._real_path(path, index)
+        exec("del self._config_inst.{}".format(real_path))
+
+    def set(self, path, value, index=0):
+        """
+        """
+        real_path = self._real_path(path, index, on_set=True)
+        try:
+            exec("self._config_inst.{} = \"{}\"".format(real_path, value))
+        except AttributeError:
+            raise ValueError("Invalid path \"{}\"".format(path)) from None
+
+    @classmethod
+    def verify_config_file(cls, config_file=None):
+        """
+        Class method to verify config file
+        """
+        inst = ConfParser(config_file)
+        inst._verify_config_file()
+
+    @classmethod
+    def get_value(cls, path, index=0):
+        """
+        Class method to get value
+        Return None if not found
+        """
+        inst = cls()
+        inst.convert2dict()
+        return inst.get(path, index)
+
+    @classmethod
+    def get_values(cls, path):
+        """
+        Class method to get value list matched by path
+        Return [] if not matched
+        """
+        inst = cls()
+        inst.convert2dict()
+        return inst.get_all(path)
+
+    @classmethod
+    def set_value(cls, path, value, index=0):
+        """
+        Class method to set value for path
+        Then write back to config file
+        """
+        inst = cls()
+        inst.convert2dict()
+        inst.set(path, value, index)
+        utils.str2file(inst.convert2string(), inst._config_file)

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -224,19 +224,15 @@ Note:
                             help="Enable SBD even if no SBD device is configured (diskless mode)")
         parser.add_argument("-w", "--watchdog", dest="watchdog", metavar="WATCHDOG",
                             help="Use the given watchdog device or driver name")
-        parser.add_argument("--no-overwrite-sshkey", action="store_true", dest="no_overwrite_sshkey",
-                            help='Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is used (False by default)')
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
-        network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(),
-                                   help="Bind to IP address on interface IF. Use -i second time for second interface")
-        network_group.add_argument("-u", "--unicast", action="store_true", dest="unicast",
-                                   help="Configure corosync to communicate over unicast (UDP), and not multicast. " +
-                                   "Default is multicast unless an environment where multicast cannot be used is detected.")
+        network_group.add_argument("-i", "--interface", dest="nic_addr_list", metavar="IF", action="append",
+                                   help="Bind to IP address on interface IF. Allowed value is nic name or IP address, if provide nic name, the first IP of that nic will be used. " +
+                                   "Use multiple -i for more links. Note: only one link is allowed for the non-knet transport type.")
+        network_group.add_argument("-t", "--transport", dest="transport", metavar="TRANSPORT", default="knet", choices=['knet', 'udpu', 'udp'],
+                                   help="The transport mechanism. Allowed value is knet(kronosnet)/udpu(unicast)/udp(multicast). Default is knet")
         network_group.add_argument("-A", "--admin-ip", dest="admin_ip", metavar="IP",
                                    help="Configure IP address as an administration virtual IP")
-        network_group.add_argument("-M", "--multi-heartbeats", action="store_true", dest="second_heartbeat",
-                                   help="Configure corosync with second heartbeat line")
         network_group.add_argument("-I", "--ipv6", action="store_true", dest="ipv6",
                                    help="Configure corosync use IPv6")
 
@@ -334,12 +330,12 @@ If stage is not specified, each stage will be invoked in sequence.
         parser.add_argument("-h", "--help", action="store_true", dest="help", help="Show this help message")
         parser.add_argument("-q", "--quiet", help="Be quiet (don't describe what's happening, just do it)", action="store_true", dest="quiet")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
-        parser.add_argument("-w", "--watchdog", dest="watchdog", metavar="WATCHDOG", help="Use the given watchdog device")
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_argument("-c", "--cluster-node", dest="cluster_node", help="IP address or hostname of existing cluster node", metavar="HOST")
-        network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(),
-                help="Bind to IP address on interface IF. Use -i second time for second interface")
+        network_group.add_argument("-i", "--interface", dest="nic_addr_list", metavar="IF", action="append",
+                help="Bind to IP address on interface IF. Allowed value is nic name or IP address, if provide nic name, the first IP of that nic will be used. " +
+                "Use multiple -i for more links. Note: only one link is allowed for the non-knet transport type.")
         options, args = parse_options(parser, args)
         if options is None or args is None:
             return


### PR DESCRIPTION
Changes/WIP include:
- Drop `--no-overwrite-sshkey` option, which already deprecated
- **Drop `-u/--unicast` option**
- **Drop `-M/--multi-heartbeats` option**
- Drop `-w/--watchdog` option on join side, which already deprecated
- **Change `-i` option accept both nic name and IP address, both on init and join side**
- **Add `-t/--transport` option, valid value include knet/udpu/udp, default is knet**
- **Write new config parser to parse corosync.conf for corosync3**
   Since original config parser couldn't modify multi interfaces
- Gradually replace related interface from corosync to conf_parser
- **Default transport type will be `knet`**
- **Enhancement option validation**, like:
  - Only one link is allowed for the non-knet transport type
  - Maximum number of interface is 8
  - Check duplicated input for -i option
  - Value type of multi -i option should be consistent
  - Transport udp (multicast) cannot be used in cloud platform
- Refactor, simplify corosync config process on init and join side
- **Not maintain/update expected_votes any more (nodelist section is mandatory)**
- **`totem.interface` section is not necessary for all transports type**

Feature list:

- [x] Configure as knet/udpu/udp
- [x] Configure as knet/udpu/udp in interactive mode
- [x] Configure qdevice with knet/udpu/udp
- [x] Configure sbd with knet/udpu/udp
- [x] Remove cluster node

Todo list:

- [ ] Unit test
- [ ] Behave functional test

Related rpm packages:
https://build.opensuse.org/package/show/home:XinLiang:corosync/crmsh
https://build.opensuse.org/project/show/home:XinLiang:corosync