### PR TITLE
Dev: sbd:

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -33,7 +33,7 @@ from . import corosync
 from . import tmpfiles
 from . import lock
 from . import userdir
-from .constants import SSH_OPTION, QDEVICE_HELP_INFO, CRM_MON_ONE_SHOT
+from .constants import SSH_OPTION, QDEVICE_HELP_INFO, CRM_MON_ONE_SHOT, STONITH_TIMEOUT_DEFAULT
 from . import ocfs2
 from . import qdevice
 from . import log
@@ -63,12 +63,13 @@ WATCHDOG_CFG = "/etc/modules-load.d/watchdog.conf"
 BOOTH_DIR = "/etc/booth"
 BOOTH_CFG = "/etc/booth/booth.conf"
 BOOTH_AUTH = "/etc/booth/authkey"
+SBD_SYSTEMD_DELAY_START_DIR = "/etc/systemd/system/sbd.service.d"
 FILES_TO_SYNC = (BOOTH_DIR, corosync.conf(), COROSYNC_AUTH, CSYNC2_CFG, CSYNC2_KEY, "/etc/ctdb/nodes",
         "/etc/drbd.conf", "/etc/drbd.d", "/etc/ha.d/ldirectord.cf", "/etc/lvm/lvm.conf", "/etc/multipath.conf",
         "/etc/samba/smb.conf", SYSCONFIG_NFS, SYSCONFIG_PCMK, SYSCONFIG_SBD, PCMK_REMOTE_AUTH, WATCHDOG_CFG,
-        PROFILES_FILE, CRM_CFG)
-
+        PROFILES_FILE, CRM_CFG, SBD_SYSTEMD_DELAY_START_DIR)
 INIT_STAGES = ("ssh", "ssh_remote", "csync2", "csync2_remote", "corosync", "sbd", "cluster", "ocfs2", "admin", "qdevice")
+
 
 class QdevicePolicy(Enum):
     QDEVICE_RELOAD = 0
@@ -698,12 +699,14 @@ def start_pacemaker(node_list=[]):
     Start pacemaker service with wait time for sbd
     When node_list set, start pacemaker service in parallel
     """
-    from .sbd import SBDManager
+    from .sbd import SBDTimeout
     pacemaker_start_msg = "Starting pacemaker"
-    if utils.package_is_installed("sbd") and \
+    # not _context means not in init or join process
+    if not _context and \
+            utils.package_is_installed("sbd") and \
             utils.service_is_enabled("sbd.service") and \
-            SBDManager.is_delay_start():
-        pacemaker_start_msg += "(waiting for sbd {}s)".format(SBDManager.get_suitable_sbd_systemd_timeout())
+            SBDTimeout.is_delay_start():
+        pacemaker_start_msg += "(waiting for sbd {}s)".format(SBDTimeout.get_suitable_sbd_systemd_timeout())
     with logger_utils.status_long(pacemaker_start_msg):
         utils.start_service("pacemaker.service", enable=True, node_list=node_list)
 
@@ -1237,7 +1240,7 @@ op_defaults op-options: timeout=600 record-pending=true
 rsc_defaults rsc-options: resource-stickiness=1 migration-threshold=3
 """)
 
-    _context.sbd_manager.configure_sbd_resource()
+    _context.sbd_manager.configure_sbd_resource_and_properties()
 
 
 def init_admin():
@@ -1334,20 +1337,17 @@ def init_qdevice():
         utils.disable_service("corosync-qdevice.service")
         return
     if _context.stage == "qdevice":
-        from .sbd import SBDManager
+        from .sbd import SBDManager, SBDTimeout
         utils.check_all_nodes_reachable()
         using_diskless_sbd = SBDManager.is_using_diskless_sbd()
         _context.qdevice_reload_policy = evaluate_qdevice_quorum_effect(QDEVICE_ADD, using_diskless_sbd)
         # add qdevice after diskless sbd started
         if using_diskless_sbd:
             res = SBDManager.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
-            if res:
-                sbd_watchdog_timeout = max(int(res), SBDManager.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE)
-            else:
-                sbd_watchdog_timeout = SBDManager.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
-            stonith_timeout = SBDManager.calculate_stonith_timeout(sbd_watchdog_timeout)
-            SBDManager.update_configuration({"SBD_WATCHDOG_TIMEOUT": str(sbd_watchdog_timeout)})
-            invokerc("crm configure property stonith-watchdog-timeout=-1 stonith-timeout={}s".format(stonith_timeout))
+            if not res or int(res) < SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE:
+                sbd_watchdog_timeout_qdevice = SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
+                SBDManager.update_configuration({"SBD_WATCHDOG_TIMEOUT": str(sbd_watchdog_timeout_qdevice)})
+                utils.set_property(stonith_timeout=int(1.2*2*sbd_watchdog_timeout_qdevice))
 
     logger.info("""Configure Qdevice/Qnetd:""")
     qdevice_inst = _context.qdevice_inst
@@ -1822,6 +1822,10 @@ def join_cluster(seed_host):
     # attempt to join the cluster failed)
     init_cluster_local()
 
+    from .sbd import SBDTimeout
+    SBDTimeout.adjust_sbd_timeout_related()
+    adjust_stonith_timeout_for_normal()
+
     with logger_utils.status_long("Reloading cluster configuration"):
 
         if ipv6_flag and not is_unicast:
@@ -1927,6 +1931,9 @@ def remove_node_from_cluster():
     """
     Remove node from running cluster and the corosync / pacemaker configuration.
     """
+    from .sbd import SBDTimeout
+    SBDTimeout.adjust_sbd_timeout_related(removing=True)
+
     node = _context.cluster_node
     set_cluster_node_ip()
 
@@ -2392,4 +2399,19 @@ def bootstrap_arbitrator(context):
     logger.info("Enabling and starting the booth arbitrator service")
     utils.start_service("booth@booth", enable=True)
 
+
+def adjust_stonith_timeout_for_normal():
+    """
+    Adjust stonith-timeout for non-sbd scenarios, formula is:
+
+    stonith-timeout >= max(STONITH_TIMEOUT_DEFAULT, token+consensus)
+    """
+    stonith_enabled = utils.get_property("stonith-enabled")
+    # When stonith disabled, return
+    if utils.is_boolean_false(stonith_enabled):
+        return
+
+    if not utils.service_is_active("sbd.service"):
+        stonith_timeout = max(STONITH_TIMEOUT_DEFAULT, corosync.token_consensus_margin())
+        utils.set_property(stonith_timeout=stonith_timeout)
 # EOF

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -524,4 +524,6 @@ STANDBY_TEMPLATE_REBOOT = """
 """
 STANDBY_NV_RE = r'(<nvpair.*{node_id}.*name="standby".*)value="{value}"(.*)'
 CRM_MON_ONE_SHOT = "crm_mon -1"
+STONITH_TIMEOUT_DEFAULT = 60
+PCMK_DELAY_MAX = 30
 # vim:ts=4:sw=4:et:

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -17,6 +17,9 @@ from . import log
 logger = log.setup_logger(__name__)
 
 
+COROSYNC_TOKEN_DEFAULT = 1000  # in ms units
+
+
 def conf():
     return os.getenv('COROSYNC_MAIN_CONFIG_FILE', '/etc/corosync/corosync.conf')
 
@@ -762,3 +765,39 @@ def create_configuration(clustername="hacluster",
                               _COROSYNC_CONF_TEMPLATE_RING_ALL + \
                               _COROSYNC_CONF_TEMPLATE_TAIL
     utils.str2file(_COROSYNC_CONF_TEMPLATE % config_common, conf())
+
+
+def get_corosync_value(key):
+    """
+    Get corosync configuration value from corosync-cmapctl or corosync.conf
+    """
+    try:
+        out = utils.get_stdout_or_raise_error("corosync-cmapctl {}".format(key))
+        res = re.search(r'{}\s+.*=\s+(.*)'.format(key), out)
+        return res.group(1) if res else None
+    except ValueError:
+        out = get_value(key)
+        return out
+
+
+def get_corosync_value_dict():
+    """
+    Get corosync value, then return these values as dict
+    """
+    value_dict = {}
+
+    token = get_corosync_value("totem.token")
+    value_dict["token"] = int(int(token)/1000) if token else int(COROSYNC_TOKEN_DEFAULT/1000)
+
+    consensus = get_corosync_value("totem.consensus")
+    value_dict["consensus"] = int(int(consensus)/1000) if consensus else int(value_dict["token"]*1.2)
+
+    return value_dict
+
+
+def token_consensus_margin():
+    """
+    Get corosync token plus consensus timeout
+    """
+    _dict = get_corosync_value_dict()
+    return _dict["token"] + _dict["consensus"]

--- a/crmsh/crash_test/utils.py
+++ b/crmsh/crash_test/utils.py
@@ -98,32 +98,20 @@ def json_dumps():
         os.fsync(f)
 
 
-def get_property(name):
-    """
-    Get cluster properties
-    """
-    cmd = "crm configure get_property " + name
-    rc, stdout, _ = crmshutils.get_stdout_stderr(cmd)
-    if rc != 0:
-        return None
-    else:
-        return stdout
-
-
 class FenceInfo(object):
     """
     Class to collect fence info
     """
     @property
     def fence_enabled(self):
-        enable_result = get_property("stonith-enabled")
+        enable_result = crmshutils.get_property("stonith-enabled")
         if not enable_result or enable_result.lower() != "true":
             return False
         return True
 
     @property
     def fence_action(self):
-        action_result = get_property("stonith-action")
+        action_result = crmshutils.get_property("stonith-action")
         if action_result is None or action_result not in ["off", "poweroff", "reboot"]:
             msg_error("Cluster property \"stonith-action\" should be reboot|off|poweroff")
             return None
@@ -131,7 +119,7 @@ class FenceInfo(object):
 
     @property
     def fence_timeout(self):
-        timeout_result = get_property("stonith-timeout")
+        timeout_result = crmshutils.get_property("stonith-timeout")
         if timeout_result and re.match(r'[1-9][0-9]*(s|)$', timeout_result):
             return timeout_result.strip("s")
         return config.FENCE_TIMEOUT

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -3,12 +3,253 @@ import re
 import shutil
 from . import utils
 from . import bootstrap
-from .bootstrap import SYSCONFIG_SBD
+from .bootstrap import SYSCONFIG_SBD, SBD_SYSTEMD_DELAY_START_DIR
 from . import log
+from . import constants
+from . import corosync
 
 
 logger = log.setup_logger(__name__)
 logger_utils = log.LoggerUtils(logger)
+
+
+class SBDTimeout(object):
+    """
+    Consolidate sbd related timeout methods and constants
+    """
+    STONITH_WATCHDOG_TIMEOUT_DEFAULT = -1
+    SBD_WATCHDOG_TIMEOUT_DEFAULT = 5
+    SBD_WATCHDOG_TIMEOUT_DEFAULT_S390 = 15
+    SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE = 35
+    QDEVICE_SYNC_TIMEOUT_MARGIN = 5
+
+    def __init__(self, context=None, removing=False):
+        """
+        Init function
+        """
+        self.context = context
+        self.sbd_msgwait = None
+        self.stonith_timeout = None
+        self.sbd_watchdog_timeout = self.SBD_WATCHDOG_TIMEOUT_DEFAULT
+        self.stonith_watchdog_timeout = self.STONITH_WATCHDOG_TIMEOUT_DEFAULT
+        self.sbd_delay_start = None
+        self.removing = removing
+        self.two_node_without_qdevice = False
+
+    def set_sbd_watchdog_timeout(self):
+        """
+        Set sbd_watchdog_timeout from profiles.yml if exists
+        Then adjust it if in s390 environment
+        """
+        if "sbd.watchdog_timeout" in self.context.profiles_dict:
+            self.sbd_watchdog_timeout = int(self.context.profiles_dict["sbd.watchdog_timeout"])
+        if self.context.is_s390 and self.sbd_watchdog_timeout < self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390:
+            logger.warning("sbd_watchdog_timeout is set to %d for s390, it was %d", self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390, self.sbd_watchdog_timeout)
+            self.sbd_watchdog_timeout = self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390
+
+    def set_sbd_msgwait(self):
+        """
+        Set sbd msgwait from profiles.yml if exists
+        Default is 2 * sbd_watchdog_timeout
+        """
+        sbd_msgwait_default = 2 * self.sbd_watchdog_timeout
+        sbd_msgwait = sbd_msgwait_default
+        if "sbd.msgwait" in self.context.profiles_dict:
+            sbd_msgwait = int(self.context.profiles_dict["sbd.msgwait"])
+            if sbd_msgwait < sbd_msgwait_default:
+                logger.warning("sbd msgwait is set to %d, it was %d", sbd_msgwait_default, sbd_msgwait)
+                sbd_msgwait = sbd_msgwait_default
+        self.sbd_msgwait = sbd_msgwait
+
+    def adjust_sbd_watchdog_timeout_with_diskless_and_qdevice(self):
+        """
+        When using diskless SBD with Qdevice, adjust value of sbd_watchdog_timeout
+        """
+        # add sbd after qdevice started
+        if utils.is_qdevice_configured() and utils.service_is_active("corosync-qdevice.service"):
+            qdevice_sync_timeout = utils.get_qdevice_sync_timeout()
+            if self.sbd_watchdog_timeout <= qdevice_sync_timeout:
+                watchdog_timeout_with_qdevice = qdevice_sync_timeout + self.QDEVICE_SYNC_TIMEOUT_MARGIN
+                logger.warning("sbd_watchdog_timeout is set to {} for qdevice, it was {}".format(watchdog_timeout_with_qdevice, self.sbd_watchdog_timeout))
+                self.sbd_watchdog_timeout = watchdog_timeout_with_qdevice
+        # add sbd and qdevice together from beginning
+        elif self.context.qdevice_inst:
+            if self.sbd_watchdog_timeout < self.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE:
+                logger.warning("sbd_watchdog_timeout is set to {} for qdevice, it was {}".format(self.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE, self.sbd_watchdog_timeout))
+                self.sbd_watchdog_timeout = self.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
+
+    @staticmethod
+    def get_sbd_msgwait(dev):
+        """
+        Get msgwait for sbd device
+        """
+        out = utils.get_stdout_or_raise_error("sbd -d {} dump".format(dev))
+        # Format like "Timeout (msgwait)  : 30"
+        res = re.search("\(msgwait\)\s+:\s+(\d+)", out)
+        if not res:
+            raise ValueError("Cannot get sbd msgwait for {}".format(dev))
+        return int(res.group(1))
+
+    @staticmethod
+    def get_sbd_watchdog_timeout():
+        """
+        Get SBD_WATCHDOG_TIMEOUT from /etc/sysconfig/sbd
+        """
+        res = SBDManager.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
+        if not res:
+            raise ValueError("Cannot get the value of SBD_WATCHDOG_TIMEOUT")
+        return int(res)
+
+    @staticmethod
+    def get_stonith_watchdog_timeout():
+        """
+        For non-bootstrap case, get stonith-watchdog-timeout value from cluster property
+        """
+        default = SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT
+        if not utils.service_is_active("pacemaker.service"):
+            return default
+        value = utils.get_property("stonith-watchdog-timeout")
+        return int(value.strip('s')) if value else default
+
+    def _load(self):
+        """
+        """
+        self.two_node_without_qdevice = utils.is_2node_cluster_without_qdevice(self.removing)
+
+        dev_list = SBDManager.get_sbd_device_from_config()
+        if dev_list:  # disk-based
+            self.disk_based = True
+            self.msgwait = SBDTimeout.get_sbd_msgwait(dev_list[0])
+            self.pcmk_delay_max = utils.get_pcmk_delay_max(self.two_node_without_qdevice)
+        else:  # disk-less
+            self.disk_based = False
+            self.sbd_watchdog_timeout = SBDTimeout.get_sbd_watchdog_timeout()
+            self.stonith_watchdog_timeout = SBDTimeout.get_stonith_watchdog_timeout()
+
+        self.sbd_delay_start_value = self.get_sbd_delay_start_value()
+        logger.debug("Inspect SBDTimeout: %s", vars(self))
+
+    def get_stonith_timeout(self):
+        """
+        Get stonith-timeout value for sbd cases, formulas are:
+
+        stonith-timeout = 1.2 * (pcmk_delay_max + msgwait) # for disk-based sbd
+        stonith-timeout = 1.2 * max (stonith_watchdog_timeout, 2*SBD_WATCHDOG_TIMEOUT)   # for disk-less sbd
+        """
+        if self.disk_based:
+            value = int(1.2*(self.pcmk_delay_max + self.msgwait))
+        else:
+            value = int(1.2*max(self.stonith_watchdog_timeout, 2*self.sbd_watchdog_timeout))
+        logger.debug("Result of SBDTimeout.get_stonith_timeout %d", value)
+        return value
+
+    def get_sbd_delay_start_value(self):
+        """
+        Get the value for SBD_DELAY_START, formulas are:
+
+        SBD_DELAY_START = (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
+        SBD_DELAY_START = (token + consensus + 2*SBD_WATCHDOG_TIMEOUT) # for disk-less sbd
+        """
+        value_from_calculation = 0
+        token_consensus_margin = corosync.token_consensus_margin()
+        if self.disk_based:
+            value_from_calculation = token_consensus_margin + self.pcmk_delay_max + self.msgwait
+        else:
+            value_from_calculation = token_consensus_margin + 2*self.sbd_watchdog_timeout
+
+        value_from_configuration = SBDManager.get_sbd_value_from_config("SBD_DELAY_START")
+        if re.search(r'\d+', value_from_configuration):
+            adjust_value = max(int(value_from_configuration), value_from_calculation)
+        else:
+            adjust_value = value_from_calculation
+        return adjust_value
+
+    @staticmethod
+    def get_suitable_sbd_systemd_timeout():
+        """
+        Get suitable systemd start timeout for sbd.service
+        """
+        return int(1.2 * int(SBDManager.get_sbd_value_from_config("SBD_DELAY_START")))
+
+    @staticmethod
+    def is_delay_start():
+        """
+        Check if SBD_DELAY_START is not no or not set
+        """
+        res = SBDManager.get_sbd_value_from_config("SBD_DELAY_START")
+        return res and res != "no"
+
+    def adjust_systemd_start_timeout(self):
+        """
+        Adjust start timeout for sbd when set SBD_DELAY_START
+        """
+        if not self.two_node_without_qdevice and os.path.isdir(SBD_SYSTEMD_DELAY_START_DIR):
+            shutil.rmtree(SBD_SYSTEMD_DELAY_START_DIR)
+            bootstrap.csync2_update(SBD_SYSTEMD_DELAY_START_DIR)
+            utils.cluster_run_cmd("systemctl daemon-reload")
+            return
+
+        # TimeoutStartUSec default is 1min 30s, need to parse as seconds
+        cmd = "systemctl show -p TimeoutStartUSec sbd --value"
+        out = utils.get_stdout_or_raise_error(cmd)
+        res_seconds = re.search("(\d+)s", out)
+        default_start_timeout = int(res_seconds.group(1)) if res_seconds else 0
+        res_min = re.search("(\d+)min", out)
+        default_start_timeout += 60 * int(res_min.group(1)) if res_min else 0
+        if default_start_timeout >= self.sbd_delay_start_value:
+            return
+
+        utils.mkdirp(SBD_SYSTEMD_DELAY_START_DIR)
+        sbd_delay_start_file = "{}/sbd_delay_start.conf".format(SBD_SYSTEMD_DELAY_START_DIR)
+        utils.str2file("[Service]\nTimeoutSec={}".format(int(1.2*self.sbd_delay_start_value)), sbd_delay_start_file)
+        bootstrap.csync2_update(SBD_SYSTEMD_DELAY_START_DIR)
+        utils.cluster_run_cmd("systemctl daemon-reload")
+
+    def adjust_stonith_timeout(self):
+        """
+        Adjust stonith-timeout property
+        """
+        utils.set_property(stonith_timeout=self.get_stonith_timeout())
+
+    def adjust_pcmk_delay_max(self):
+        """
+        Adjust pcmk_delay_max parameter for sbd ra
+        """
+        if not utils.has_resource_configured(SBDManager.SBD_RA):
+            return
+
+        if self.two_node_without_qdevice:
+            cmd = "crm resource param {} set pcmk_delay_max {}s".format(SBDManager.SBD_RA_ID, self.pcmk_delay_max)
+        else:
+            cmd = "crm resource param {} delete pcmk_delay_max".format(SBDManager.SBD_RA_ID)
+        utils.get_stdout_or_raise_error(cmd)
+
+    def adjust_delay_start(self):
+        """
+        Adjust SBD_DELAY_START in /etc/sysconfig/sbd
+        """
+        value = str(self.sbd_delay_start_value) if self.two_node_without_qdevice else "no"
+        SBDManager.update_configuration({"SBD_DELAY_START": value})
+
+    @classmethod
+    def adjust_sbd_timeout_related(cls, removing=False):
+        """
+        """
+        if not utils.service_is_active("sbd.service") or not utils.detect_virt():
+            return
+
+        cls_inst = cls(removing=removing)
+        cls_inst._load()
+
+        message = "Adjusting sbd related timeout values for 2-node cluster"
+        if not cls_inst.two_node_without_qdevice:
+            message = "Reverting sbd related timeout values for non 2-node cluster"
+
+        with logger_utils.status_long(message):
+            cls_inst.adjust_delay_start()
+            cls_inst.adjust_pcmk_delay_max()
+            cls_inst.adjust_stonith_timeout()
+            cls_inst.adjust_systemd_start_timeout()
 
 
 class SBDManager(object):
@@ -26,14 +267,11 @@ class SBDManager(object):
   specify here will be destroyed.
 """
     SBD_WARNING = "Not configuring SBD - STONITH will be disabled."
-    DISKLESS_SBD_WARNING = """Diskless SBD requires cluster with three or more nodes.
-If you want to use diskless SBD for two-nodes cluster, should be combined with QDevice."""
+    DISKLESS_SBD_WARNING = "Diskless SBD requires cluster with three or more nodes. If you want to use diskless SBD for two-nodes cluster, should be combined with QDevice."
     PARSE_RE = "[; ]"
     DISKLESS_CRM_CMD = "crm configure property stonith-enabled=true stonith-watchdog-timeout={} stonith-timeout={}"
-
-    SBD_WATCHDOG_TIMEOUT_DEFAULT = 5
-    SBD_WATCHDOG_TIMEOUT_DEFAULT_S390 = 15
-    SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE = 35
+    SBD_RA = "stonith:external/sbd"
+    SBD_RA_ID = "stonith-sbd"
 
     def __init__(self, context):
         """
@@ -46,14 +284,9 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         self.diskless_sbd = context.diskless_sbd
         self._sbd_devices = None
         self._watchdog_inst = None
-        self._stonith_timeout = 60
-        if context.is_s390:
-            self._sbd_watchdog_timeout = self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390
-        else:
-            self._sbd_watchdog_timeout = self.SBD_WATCHDOG_TIMEOUT_DEFAULT
-        self._stonith_watchdog_timeout = -1
         self._context = context
         self._delay_start = False
+        self.timeout_inst = None
 
     @staticmethod
     def _get_device_uuid(dev, node=None):
@@ -65,18 +298,6 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         if not res:
             raise ValueError("Cannot find sbd device UUID for {}".format(dev))
         return res.group(1)
-
-    @staticmethod
-    def _get_sbd_msgwait(dev):
-        """
-        Get msgwait for sbd device
-        """
-        out = utils.get_stdout_or_raise_error("sbd -d {} dump".format(dev))
-        # Format like "Timeout (msgwait)  : 30"
-        res = re.search("\(msgwait\)\s+:\s+(\d+)", out)
-        if not res:
-            raise ValueError("Cannot get sbd msgwait for {}".format(dev))
-        return int(res.group(1))
 
     def _compare_device_uuid(self, dev, node_list):
         """
@@ -156,37 +377,22 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
             dev_list = self._get_sbd_device_interactive()
         self._sbd_devices = dev_list
 
-    def _adjust_sbd_watchdog_timeout_for_s390(self):
-        """
-        Correct watchdog timeout if less than s390 default
-        """
-        if self._context.is_s390 and self._sbd_watchdog_timeout < self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390:
-            logger.warning("sbd_watchdog_timeout is set to {} for s390, it was {}".format(self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390, self._sbd_watchdog_timeout))
-            self._sbd_watchdog_timeout = self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390
-
     def _initialize_sbd(self):
         """
         Initialize SBD parameters according to profiles.yml, or the crmsh defined defaulst as the last resort.
         This covers both disk-based-sbd, and diskless-sbd scenarios.
-        For diskless-sbd, set _sbd_watchdog_timeout then return;
+        For diskless-sbd, set sbd_watchdog_timeout then return;
         For disk-based-sbd, also calculate the msgwait value, then initialize the SBD device.
         """
         logger.info("Initializing {}SBD".format("diskless " if self.diskless_sbd else ""))
-
-        if "sbd.watchdog_timeout" in self._context.profiles_dict:
-            self._sbd_watchdog_timeout = self._context.profiles_dict["sbd.watchdog_timeout"]
-            self._adjust_sbd_watchdog_timeout_for_s390()
+        self.timeout_inst = SBDTimeout(self._context)
+        self.timeout_inst.set_sbd_watchdog_timeout()
         if self.diskless_sbd:
+            self.timeout_inst.adjust_sbd_watchdog_timeout_with_diskless_and_qdevice()
             return
 
-        sbd_msgwait_default = int(self._sbd_watchdog_timeout) * 2
-        sbd_msgwait = sbd_msgwait_default
-        if "sbd.msgwait" in self._context.profiles_dict:
-            sbd_msgwait = self._context.profiles_dict["sbd.msgwait"]
-            if int(sbd_msgwait) < sbd_msgwait_default:
-                logger.warning("sbd msgwait is set to {}, it was {}".format(sbd_msgwait_default, sbd_msgwait))
-                sbd_msgwait = sbd_msgwait_default
-        opt = "-4 {} -1 {}".format(sbd_msgwait, self._sbd_watchdog_timeout)
+        self.timeout_inst.set_sbd_msgwait()
+        opt = "-4 {} -1 {}".format(self.timeout_inst.sbd_msgwait, self.timeout_inst.sbd_watchdog_timeout)
 
         for dev in self._sbd_devices:
             rc, _, err = bootstrap.invoke("sbd {} -d {} create".format(opt, dev))
@@ -198,42 +404,14 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         Update /etc/sysconfig/sbd
         """
         shutil.copyfile(self.SYSCONFIG_SBD_TEMPLATE, SYSCONFIG_SBD)
-        self._adjust_sbd_watchdog_timeout_with_diskless_and_qdevice()
-        if utils.detect_virt():
-            self._delay_start = True
         sbd_config_dict = {
-                "SBD_PACEMAKER": "yes",
-                "SBD_STARTMODE": "always",
-                "SBD_DELAY_START": "yes" if self._delay_start else "no",
-                "SBD_WATCHDOG_DEV": self._watchdog_inst.watchdog_device_name
+                "SBD_WATCHDOG_DEV": self._watchdog_inst.watchdog_device_name,
+                "SBD_WATCHDOG_TIMEOUT": str(self.timeout_inst.sbd_watchdog_timeout)
                 }
-        if self._sbd_watchdog_timeout > 0:
-            sbd_config_dict["SBD_WATCHDOG_TIMEOUT"] = str(self._sbd_watchdog_timeout)
         if self._sbd_devices:
             sbd_config_dict["SBD_DEVICE"] = ';'.join(self._sbd_devices)
         utils.sysconfig_set(SYSCONFIG_SBD, **sbd_config_dict)
         bootstrap.csync2_update(SYSCONFIG_SBD)
-
-    def _adjust_sbd_watchdog_timeout_with_diskless_and_qdevice(self):
-        """
-        When using diskless SBD with Qdevice, adjust value of sbd_watchdog_timeout
-        """
-        if not self.diskless_sbd:
-            return
-        # add sbd after qdevice started
-        if utils.is_qdevice_configured() and utils.service_is_active("corosync-qdevice.service"):
-            qdevice_sync_timeout = utils.get_qdevice_sync_timeout()
-            if self._sbd_watchdog_timeout <= qdevice_sync_timeout:
-                watchdog_timeout_with_qdevice = qdevice_sync_timeout + 5
-                logger.warning("sbd_watchdog_timeout is set to {} for qdevice, it was {}".format(watchdog_timeout_with_qdevice, self._sbd_watchdog_timeout))
-                self._sbd_watchdog_timeout = watchdog_timeout_with_qdevice
-            self._stonith_timeout = self.calculate_stonith_timeout(self._sbd_watchdog_timeout)
-        # add sbd and qdevice together from beginning
-        elif self._context.qdevice_inst:
-            if self._sbd_watchdog_timeout < self.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE:
-                logger.warning("sbd_watchdog_timeout is set to {} for qdevice, it was {}".format(self.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE, self._sbd_watchdog_timeout))
-                self._sbd_watchdog_timeout = self.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
-            self._stonith_timeout = self.calculate_stonith_timeout(self._sbd_watchdog_timeout)
 
     def _get_sbd_device_from_config(self):
         """
@@ -245,44 +423,6 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         else:
             return None
 
-    @staticmethod
-    def is_delay_start():
-        """
-        Check if SBD_DELAY_START is yes
-        """
-        res = SBDManager.get_sbd_value_from_config("SBD_DELAY_START")
-        return utils.is_boolean_true(res)
-
-    @staticmethod
-    def get_sbd_watchdog_timeout():
-        """
-        Get SBD_WATCHDOG_TIMEOUT from /etc/sysconfig/sbd
-        """
-        res = SBDManager.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
-        if not res:
-            raise ValueError("Cannot get the value of SBD_WATCHDOG_TIMEOUT")
-        return int(res)
-
-    @staticmethod
-    def get_sbd_start_timeout_threshold():
-        """
-        Get sbd start timeout threshold
-        TimeoutStartUSec of sbd shouldn't less than this value
-        """
-        dev_list = SBDManager.get_sbd_device_from_config()
-        if not dev_list:
-            return int(SBDManager.get_sbd_watchdog_timeout() * 2)
-        else:
-            return int(SBDManager._get_sbd_msgwait(dev_list[0]))
-
-    @staticmethod
-    def get_suitable_sbd_systemd_timeout():
-        """
-        Get suitable systemd start timeout for sbd.service
-        """
-        timeout_value = SBDManager.get_sbd_start_timeout_threshold()
-        return int(timeout_value * 1.2)
-
     def _restart_cluster_and_configure_sbd_ra(self):
         """
         Try to configure sbd resource, restart cluster on needed
@@ -291,14 +431,14 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
             logger.info("Restarting cluster service")
             utils.cluster_run_cmd("crm cluster restart")
             bootstrap.wait_for_cluster()
-            self.configure_sbd_resource()
+            self.configure_sbd_resource_and_properties()
         else:
             logger.warning("To start sbd.service, need to restart cluster service manually on each node")
             if self.diskless_sbd:
-                cmd = self.DISKLESS_CRM_CMD.format(self._stonith_watchdog_timeout, str(self._stonith_timeout)+"s")
+                cmd = self.DISKLESS_CRM_CMD.format(self.timeout_inst.stonith_watchdog_timeout, SBDTimeout.get_stonith_timeout())
                 logger.warning("Then run \"{}\" on any node".format(cmd))
             else:
-                self.configure_sbd_resource()
+                self.configure_sbd_resource_and_properties()
 
     def _enable_sbd_service(self):
         """
@@ -311,29 +451,6 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         else:
             # in init process
             bootstrap.invoke("systemctl enable sbd.service")
-
-    def _adjust_systemd(self):
-        """
-        Adjust start timeout for sbd when set SBD_DELAY_START
-        """
-        if not self.is_delay_start():
-            return
-
-        # TimeoutStartUSec default is 1min 30s, need to parse as seconds
-        cmd = "systemctl show -p TimeoutStartUSec sbd --value"
-        out = utils.get_stdout_or_raise_error(cmd)
-        res_seconds = re.search("(\d+)s", out)
-        default_start_timeout = int(res_seconds.group(1)) if res_seconds else 0
-        res_min = re.search("(\d+)min", out)
-        default_start_timeout += 60 * int(res_min.group(1)) if res_min else 0
-        if default_start_timeout >= self.get_sbd_start_timeout_threshold():
-            return
-
-        systemd_sbd_dir = "/etc/systemd/system/sbd.service.d"
-        utils.mkdirp(systemd_sbd_dir)
-        sbd_delay_start_file = "{}/sbd_delay_start.conf".format(systemd_sbd_dir)
-        utils.str2file("[Service]\nTimeoutSec={}".format(self.get_suitable_sbd_systemd_timeout()), sbd_delay_start_file)
-        utils.get_stdout_or_raise_error("systemctl daemon-reload")
 
     def _warn_diskless_sbd(self, peer=None):
         """
@@ -370,26 +487,28 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         self._initialize_sbd()
         self._update_sbd_configuration()
         self._enable_sbd_service()
-        self._adjust_systemd()
 
-    def configure_sbd_resource(self):
+    def configure_sbd_resource_and_properties(self):
         """
-        Configure stonith-sbd resource and stonith-enabled property
+        Configure stonith-sbd resource and related properties
         """
         if not utils.package_is_installed("sbd") or \
                 not utils.service_is_enabled("sbd.service") or \
-                utils.has_resource_configured("stonith:external/sbd"):
+                utils.has_resource_configured(self.SBD_RA):
             return
 
+        # disk-based sbd
         if self._get_sbd_device_from_config():
-            if not bootstrap.invokerc("crm configure primitive stonith-sbd stonith:external/sbd pcmk_delay_max=30s"):
-                utils.fatal("Can't create stonith-sbd primitive")
-            if not bootstrap.invokerc("crm configure property stonith-enabled=true"):
-                utils.fatal("Can't enable STONITH for SBD")
+            utils.get_stdout_or_raise_error("crm configure primitive {} {}".format(self.SBD_RA_ID, self.SBD_RA))
+            utils.set_property(stonith_enabled="true")
+        # disk-less sbd
         else:
-            cmd = self.DISKLESS_CRM_CMD.format(self._stonith_watchdog_timeout, str(self._stonith_timeout)+"s")
-            if not bootstrap.invokerc(cmd):
-                utils.fatal("Can't enable STONITH for diskless SBD")
+            cmd = self.DISKLESS_CRM_CMD.format(self.timeout_inst.stonith_watchdog_timeout, constants.STONITH_TIMEOUT_DEFAULT)
+            utils.get_stdout_or_raise_error(cmd)
+
+        # in sbd stage
+        if self._context.cluster_is_running:
+            SBDTimeout.adjust_sbd_timeout_related()
 
     def join_sbd(self, peer_host):
         """
@@ -411,9 +530,9 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
             self._verify_sbd_device(dev_list, [peer_host])
         else:
             self._warn_diskless_sbd(peer_host)
-        self._adjust_systemd()
         logger.info("Got {}SBD configuration".format("" if dev_list else "diskless "))
         bootstrap.invoke("systemctl enable sbd.service")
+        utils.sysconfig_set(SYSCONFIG_SBD, SBD_DELAY_START="no")
 
     @classmethod
     def verify_sbd_device(cls):
@@ -453,13 +572,6 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         """
         utils.sysconfig_set(SYSCONFIG_SBD, **sbd_config_dict)
         bootstrap.csync2_update(SYSCONFIG_SBD)
-
-    @staticmethod
-    def calculate_stonith_timeout(sbd_watchdog_timeout):
-        """
-        Calculate stonith timeout
-        """
-        return int(sbd_watchdog_timeout * 2 * 1.2)
 
     @staticmethod
     def get_sbd_value_from_config(key):

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -306,3 +306,15 @@ def step_impl(context, f):
     cmd = "crm cluster diff {}".format(f)
     rc, out = run_command(context, cmd)
     assert out == ""
+
+
+@given('Resource "{res_id}" is started on "{node}"')
+def step_impl(context, res_id, node):
+    rc, out, err = crmutils.get_stdout_stderr("crm_mon -1")
+    assert re.search(r'\*\s+{}\s+.*Started\s+{}'.format(res_id, node), out) is not None
+
+
+@then('Resource "{res_id}" is started on "{node}"')
+def step_impl(context, res_id, node):
+    rc, out, err = crmutils.get_stdout_stderr("crm_mon -1")
+    assert re.search(r'\*\s+{}\s+.*Started\s+{}'.format(res_id, node), out) is not None


### PR DESCRIPTION
* Consolidate sbd timeout related methods/constants/formulas into class SBDTimeout

* Adjust stonith-timeout value, formulas are:
  stonith-timeout = 1.2 * (pcmk_delay_max + msgwait)  # for disk-based sbd
  stonith-timeout = 1.2 * max(stonith_watchdog_timeout, 2*SBD_WATCHDOG_TIMEOUT)  # for disk-less sbd
  stonith-timeout = max(STONITH_TIMEOUT_DEFAULT, token+consensus)  # for other situations

* Adjust SBD_DELAY_START value, formulas are:
  SBD_DELAY_START = no # for non virtualization environment, which is the system default
  SBD_DELAY_START = (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
  SBD_DELAY_START = (token + consensus + 2*SBD_WATCHDOG_TIMEOUT) # for disk-less sbd

* pcmk_delay_max=30 # only for the single stonith device in the 2-node cluster without qdevice
  pcmk_delay_max deletion # only for the single stonith device, not in the 2-node cluster without qdevice